### PR TITLE
Apt fix bandaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ Basics are, edit the Targets file to ping the hosts you're interested in to matc
 * lonix <lonixx@gmail.com>
 
 **Version**
-
-29.06.2015: This is the first release, it is mostly stable, but may contain minor defects. (thus a beta tag)
++**23.07.16:** Fix apt script confusion.
++**29.06.15:** This is the first release, it is mostly stable, but may contain minor defects. (thus a beta tag)

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ Basics are, edit the Targets file to ping the hosts you're interested in to matc
 * lonix <lonixx@gmail.com>
 
 **Version**
-+**23.07.16:** Fix apt script confusion.
-+**29.06.15:** This is the first release, it is mostly stable, but may contain minor defects. (thus a beta tag)
++ **23.07.16:** Fix apt script confusion.
++ **29.06.15:** This is the first release, it is mostly stable, but may contain minor defects. (thus a beta tag)

--- a/init/90_update_apt.sh
+++ b/init/90_update_apt.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-apt-get update -qq
-apt-get --only-upgrade install -yqq smokeping


### PR DESCRIPTION
temp "bandaid" fix of just removing the errant apt update script, in lieu of a proper rewrite.