### PR TITLE
Handle user defined Timezone via environment variable TZ, defaults to UTZ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM linuxserver/baseimage
 MAINTAINER LinuxServer.io <ironicbadger@linuxserver.io>
 # apache environment settings
-ENV APACHE_RUN_USER=abc APACHE_RUN_GROUP=users APACHE_LOG_DIR="/var/log/apache2" APACHE_LOCK_DIR="/var/lock/apache2" APACHE_PID_FILE="/var/run/apache2.pid"
+ENV TZ="UTC" APACHE_RUN_USER=abc APACHE_RUN_GROUP=users APACHE_LOG_DIR="/var/log/apache2" APACHE_LOCK_DIR="/var/lock/apache2" APACHE_PID_FILE="/var/run/apache2.pid"
 
 #Applying stuff
 RUN apt-get update && \

--- a/init/03_set_timezone.sh
+++ b/init/03_set_timezone.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Set timezone if defined
+if [ -e /usr/share/zoneinfo/$TZ ]; then
+	rm /etc/localtime
+	ln -s /usr/share/zoneinfo/$TZ /etc/localtime
+fi


### PR DESCRIPTION
Hi,

Currently image linuxserver/baseimage defaults to timezone UTC
Please be kind to consider user overrides via environment variable TZ

set TZ="Europe/London" would make this container show charts with the correct time for me

Cheers