### PR TITLE
changed httpd.conf DocumentRoot to point to smokeping as the default Apache page.

### DIFF
--- a/root/etc/apache2/httpd.conf
+++ b/root/etc/apache2/httpd.conf
@@ -237,8 +237,8 @@ ServerSignature On
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-DocumentRoot "/var/www/localhost/htdocs"
-<Directory "/var/www/localhost/htdocs">
+DocumentRoot "/var/www/localhost/smokeping"
+<Directory "/var/www/localhost/smokeping">
     #
     # Possible values for the Options directive are "None", "All",
     # or any combination of:
@@ -271,7 +271,7 @@ DocumentRoot "/var/www/localhost/htdocs"
 # is requested.
 #
 <IfModule dir_module>
-    DirectoryIndex index.html
+    smokeping.cgi DirectoryIndex index.html
 </IfModule>
 
 #

--- a/root/etc/apache2/httpd.conf
+++ b/root/etc/apache2/httpd.conf
@@ -271,7 +271,7 @@ DocumentRoot "/var/www/localhost/smokeping"
 # is requested.
 #
 <IfModule dir_module>
-    smokeping.cgi DirectoryIndex index.html
+    DirectoryIndex smokeping.cgi index.html
 </IfModule>
 
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is the fix that I wrote Issue #16 (Request to have smokeping come up as the default web page #16) for.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

