### PR TITLE
Fix path to cropper.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
 
 # fix path to cropper.js
 RUN \
- sed -i 's/src="\/cropper\//src="cropper\//' /etc/smokeping/basepage.html
+ sed 's#src="/cropper/#/src="cropper/#' /etc/smokeping/basepage.html
 
 # add local files
 COPY root/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN \
 RUN \
  echo "abc ALL=(ALL) NOPASSWD: /usr/bin/traceroute" >> /etc/sudoers.d/traceroute
 
+# fix path to cropper.js
+RUN \
+ sed -i 's/src="\/cropper\//src="cropper\//' /etc/smokeping/basepage.html
+
 # add local files
 COPY root/ /
 


### PR DESCRIPTION
Allows ability to click-drag to zoom on the graphs

Not sure this is the best way to fix this as it's probably an upstream issue but this corrects the path to cropper.js which then enables click and zoom on time ranges on the graph.