### PR TITLE
Redirect / to CGI

### DIFF
--- a/root/defaults/smokeping.conf
+++ b/root/defaults/smokeping.conf
@@ -1,6 +1,8 @@
 ScriptAlias /smokeping/smokeping.cgi /var/www/localhost/smokeping/smokeping.cgi
 Alias /smokeping /var/www/localhost/smokeping
 
+RedirectMatch ^/$ /smokeping/smokeping.cgi
+
 <Directory "/var/www/localhost/smokeping">
     Options +ExecCGI
     AddHandler cgi-script .cgi


### PR DESCRIPTION
If the request has no path, then redirect to the CGI for smokeping so
that people don't have to memorize the URL.

