### PR TITLE
Fix tcpping error message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN \
 	apache2 \
 	apache2-ctl \
 	apache2-utils \
+	bc \
 	curl \
 	smokeping \
 	ssmtp \


### PR DESCRIPTION
#<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
Minor fix for the `tcpping` patch -- as it turns out, it uses `bc` (via a symlink to `busybox`) to compute an upper bound for some tasks. It works all the same, but the error message is annoying, and my personal version already had `bc` installed for some reason -- with this in place I can ditch my fork.

Edit: typos.

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io
