### PR TITLE
Add redirect from root to app

### DIFF
--- a/root/defaults/httpd.conf
+++ b/root/defaults/httpd.conf
@@ -239,6 +239,10 @@ ServerSignature On
 #
 DocumentRoot "/var/www/localhost/htdocs"
 <Directory "/var/www/localhost/htdocs">
+    
+    # Redirect from root to application
+    Redirect permanent / /smokeping/smokeping.cgi
+    
     #
     # Possible values for the Options directive are "None", "All",
     # or any combination of:


### PR DESCRIPTION
_fixes #43_

It would be great for the container to provide a redirect from the url root to /smokeping/smokeping.cgi, so that you can simply access it as a client without needing the magic path.

This PR fixes this.