### PR TITLE
add python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN \
 	bc \
 	bind-tools \
 	curl \
+	python \
 	smokeping \
 	ssmtp \
 	sudo \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -22,6 +22,7 @@ RUN \
 	bc \
 	bind-tools \
 	curl \
+	python \
 	smokeping \
 	ssmtp \
 	sudo \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -22,6 +22,7 @@ RUN \
 	bc \
 	bind-tools \
 	curl \
+	python \
 	smokeping \
 	ssmtp \
 	sudo \


### PR DESCRIPTION
Having python in the smokeping image I can install 3rd party probe speedtest-cli:
```
curl -L -o /usr/local/bin/speedtest-cli https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py && chmod a+x /usr/local/bin/speedtest-cli
curl -L -o /usr/share/perl5/vendor_perl/Smokeping/probes/speedtest.pm https://github.com/mad-ady/smokeping-speedtest/raw/master/speedtest.pm
```
**Edit:**
Smokeping needs to be patched also because it's too old:
`wget -q -O - https://github.com/oetiker/SmokePing/commit/60419834f224a0735094fd4ad0aac8eac3b1528.diff | patch -p1 /usr/share/perl5/vendor_perl/Smokeping.pm
`