### PR TITLE
Improved default apache config such that fresh users directly get redirected to the smokeping "subsite"

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -29,12 +29,13 @@ param_env_vars:
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  - Once running the URL will be `http://<host-ip>/smokeping/smokeping.cgi`.
+  - Once running the URL will be `http://<host-ip>/`.
   - Basics are, edit the `Targets` file to ping the hosts you're interested in to match the format found there.
   - Wait 10 minutes.
 
 # changelog
 changelogs:
+  - { date: "14.11.18:", desc: "Allow access without /smokeping in URL." }
   - { date: "28.04.18:", desc: "Rebase to alpine 3.8." }
   - { date: "09.04.18:", desc: "Add bc package." }
   - { date: "08.04.18:", desc: "Add tccping script and tcptraceroute package (thanks rcarmo)." }

--- a/root/defaults/httpd.conf
+++ b/root/defaults/httpd.conf
@@ -274,6 +274,11 @@ DocumentRoot "/var/www/localhost/htdocs"
     DirectoryIndex index.html smokeping.cgi 
 </IfModule>
 
+# rewrite incoming root requeststo correct subpath
+RewriteEngine On
+RewriteRule ^/$ /smokeping/ [R]
+
+
 #
 # The following lines prevent .htaccess and .htpasswd files from being
 # viewed by Web clients.

--- a/root/defaults/httpd.conf
+++ b/root/defaults/httpd.conf
@@ -271,7 +271,7 @@ DocumentRoot "/var/www/localhost/htdocs"
 # is requested.
 #
 <IfModule dir_module>
-    DirectoryIndex index.html
+    DirectoryIndex index.html smokeping.cgi 
 </IfModule>
 
 #


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

As this seems to be a common request (#16 and #43) I've tried to make a configuration that is backwards compatible with the current server, while still helping fresh users.

- `smokeping.cgi` is not needed anymore, as apache also recognizes it as an index (so `/smokeping/` is sufficient)
- `/` redirects to  `/smokeping/` (so users opening the just mapped port in their browser don't get an confusing "It's working" message)

Since this container contains it's own fully dedicated http server, I think making a few of these customization as default is more user-friendly than having every user figure it out themselves.

