### PR TITLE
Update docker file to fix startup error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN \
  echo "**** install tcping script ****" && \
  install -m755 -D /defaults/tcpping /usr/bin/ && \
  echo "**** remove default apache conf ****" && \
- rm -f /etc/apache2/httpd.conf
+ rm -f /etc/apache2/httpd.conf && \
+ mkdir /var/run/smokeping
 
 # add local files
 COPY root/ /


### PR DESCRIPTION
fixes startup error
"ERROR: /config/pathnames, line 5: Directory '/var/run/smokeping' does not exist"

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

