### PR TITLE
add sudo access to tcpping. closes #65

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,16 @@ RUN \
 	sudo \
 	tcptraceroute \
 	ttf-dejavu && \
- echo "**** give abc sudo access to traceroute & tcptraceroute ****" && \
+ echo "**** give abc sudo access to traceroute & tcptraceroute & tcpping ****" && \
  echo \
  "abc ALL=(ALL) NOPASSWD: /usr/bin/traceroute" >> \
 	/etc/sudoers.d/traceroute && \
  echo \
  "abc ALL=(ALL) NOPASSWD: /usr/bin/tcptraceroute" >> \
 	/etc/sudoers.d/tcptraceroute && \
+ echo \
+ "abc ALL=(ALL) NOPASSWD: /usr/bin/tcpping" >> \
+	/etc/sudoers.d/tcpping && \
  echo "**** fix path to cropper.js ****" && \
  sed -i 's#src="/cropper/#/src="cropper/#' /etc/smokeping/basepage.html && \
  echo "**** install tcping script ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -25,13 +25,16 @@ RUN \
 	sudo \
 	tcptraceroute \
 	ttf-dejavu && \
- echo "**** give abc sudo access to traceroute & tcptraceroute ****" && \
+ echo "**** give abc sudo access to traceroute & tcptraceroute & tcpping ****" && \
  echo \
  "abc ALL=(ALL) NOPASSWD: /usr/bin/traceroute" >> \
 	/etc/sudoers.d/traceroute && \
  echo \
  "abc ALL=(ALL) NOPASSWD: /usr/bin/tcptraceroute" >> \
 	/etc/sudoers.d/tcptraceroute && \
+ echo \
+ "abc ALL=(ALL) NOPASSWD: /usr/bin/tcpping" >> \
+	/etc/sudoers.d/tcpping && \
  echo "**** fix path to cropper.js ****" && \
  sed -i 's#src="/cropper/#/src="cropper/#' /etc/smokeping/basepage.html && \
  echo "**** install tcping script ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -25,13 +25,16 @@ RUN \
 	sudo \
 	tcptraceroute \
 	ttf-dejavu && \
- echo "**** give abc sudo access to traceroute & tcptraceroute ****" && \
+ echo "**** give abc sudo access to traceroute & tcptraceroute & tcpping ****" && \
  echo \
  "abc ALL=(ALL) NOPASSWD: /usr/bin/traceroute" >> \
 	/etc/sudoers.d/traceroute && \
  echo \
  "abc ALL=(ALL) NOPASSWD: /usr/bin/tcptraceroute" >> \
 	/etc/sudoers.d/tcptraceroute && \
+ echo \
+ "abc ALL=(ALL) NOPASSWD: /usr/bin/tcpping" >> \
+	/etc/sudoers.d/tcpping && \
  echo "**** fix path to cropper.js ****" && \
  sed -i 's#src="/cropper/#/src="cropper/#' /etc/smokeping/basepage.html && \
  echo "**** install tcping script ****" && \


### PR DESCRIPTION
While I would prefer using setuid on tcptraceroute instead, following the convention already in use, adding sudo access to tcpping so that it can be used by the abc user for smokeping.