### PR TITLE
use setuid instead of sudo to allow tcpping, tcptraceroute and tracero…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,9 @@ RUN \
 	sudo \
 	tcptraceroute \
 	ttf-dejavu && \
- echo "**** give abc sudo access to traceroute & tcptraceroute & tcpping ****" && \
- echo \
- "abc ALL=(ALL) NOPASSWD: /usr/bin/traceroute" >> \
-	/etc/sudoers.d/traceroute && \
- echo \
- "abc ALL=(ALL) NOPASSWD: /usr/bin/tcptraceroute" >> \
-	/etc/sudoers.d/tcptraceroute && \
- echo \
- "abc ALL=(ALL) NOPASSWD: /usr/bin/tcpping" >> \
-	/etc/sudoers.d/tcpping && \
+ echo "**** give setuid access to traceroute & tcptraceroute ****" && \
+ chmod a+s /usr/bin/traceroute && \
+ chmod a+s /usr/bin/tcptraceroute && \
  echo "**** fix path to cropper.js ****" && \
  sed -i 's#src="/cropper/#/src="cropper/#' /etc/smokeping/basepage.html && \
  echo "**** install tcping script ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -25,16 +25,9 @@ RUN \
 	sudo \
 	tcptraceroute \
 	ttf-dejavu && \
- echo "**** give abc sudo access to traceroute & tcptraceroute & tcpping ****" && \
- echo \
- "abc ALL=(ALL) NOPASSWD: /usr/bin/traceroute" >> \
-	/etc/sudoers.d/traceroute && \
- echo \
- "abc ALL=(ALL) NOPASSWD: /usr/bin/tcptraceroute" >> \
-	/etc/sudoers.d/tcptraceroute && \
- echo \
- "abc ALL=(ALL) NOPASSWD: /usr/bin/tcpping" >> \
-	/etc/sudoers.d/tcpping && \
+ echo "**** give setuid access to traceroute & tcptraceroute ****" && \
+ chmod a+s /usr/bin/traceroute && \
+ chmod a+s /usr/bin/tcptraceroute && \
  echo "**** fix path to cropper.js ****" && \
  sed -i 's#src="/cropper/#/src="cropper/#' /etc/smokeping/basepage.html && \
  echo "**** install tcping script ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -25,16 +25,9 @@ RUN \
 	sudo \
 	tcptraceroute \
 	ttf-dejavu && \
- echo "**** give abc sudo access to traceroute & tcptraceroute & tcpping ****" && \
- echo \
- "abc ALL=(ALL) NOPASSWD: /usr/bin/traceroute" >> \
-	/etc/sudoers.d/traceroute && \
- echo \
- "abc ALL=(ALL) NOPASSWD: /usr/bin/tcptraceroute" >> \
-	/etc/sudoers.d/tcptraceroute && \
- echo \
- "abc ALL=(ALL) NOPASSWD: /usr/bin/tcpping" >> \
-	/etc/sudoers.d/tcpping && \
+ echo "**** give setuid access to traceroute & tcptraceroute ****" && \
+ chmod a+s /usr/bin/traceroute && \
+ chmod a+s /usr/bin/tcptraceroute && \
  echo "**** fix path to cropper.js ****" && \
  sed -i 's#src="/cropper/#/src="cropper/#' /etc/smokeping/basepage.html && \
  echo "**** install tcping script ****" && \


### PR DESCRIPTION
In issue #65 I suggested setuid, but went with sudo as that was already used in the Dockerfile previously.

After more testing I found that I can't actually use sudo in the config.

Example config:
```
+ TCPPing
binary = /usr/bin/sudo /usr/bin/tcpping
forks = 5
offset = 50%
step = 300
timeout = 15
# The following variables can be overridden in each target section
pings = 5
port = 80
```

This results in an error:
```
ERROR: /config/Probes, line 7: ERROR: TCPPing 'binary' does not point to an executable
```

So instead the binary has to look like this in the config:
```
+ TCPPing
binary = /usr/bin/tcpping
```

tcpping doesn't need setui/sudo access in this case, but tcptraceroute does. 
Also updating regular traceroute so that https://oss.oetiker.ch/smokeping/probe/TraceroutePing.en.html is also usable.

