### PR TITLE
Hide the Apache version on the Server header

### DIFF
--- a/root/defaults/httpd.conf
+++ b/root/defaults/httpd.conf
@@ -26,7 +26,7 @@
 # Set to one of:  Full | OS | Minor | Minimal | Major | Prod
 # where Full conveys the most information, and Prod the least.
 #
-ServerTokens OS
+ServerTokens Prod
 
 #
 # ServerRoot: The top of the directory tree under which the server's
@@ -204,7 +204,7 @@ ServerAdmin you@example.com
 # Set to "EMail" to also include a mailto: link to the ServerAdmin.
 # Set to one of:  On | Off | EMail
 #
-ServerSignature On
+ServerSignature Off
 
 #
 # ServerName gives the name and port that the server uses to identify itself.


### PR DESCRIPTION
This change will hide information about the running Apache version. It is not relevant having this information on a running system, except during deployment/debugging.