### PR TITLE
When exists, have ssmtp.conf copied to appropriate folder

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -35,8 +35,8 @@ cd "${PREV_DIR}" || exit
 [[ ! -L /etc/apache2/httpd.conf ]] && \
 	ln -sf /config/httpd.conf /etc/apache2/httpd.conf
 
-[[ ! -e /config/smtp.conf ]] && \
-	cp /config/smtp.conf /etc/ssmtp/ssmtp.conf
+[[ -e /config/ssmtp.conf ]] && \
+	cp /config/ssmtp.conf /etc/ssmtp/ssmtp.conf
 
 # permissions
 chown -R abc:abc \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
<!--- Describe your changes in detail -->

It appears that ssmtp.conf isn't copied from the /config folder to /etc/ssmtp when it exists. It looks like it should have been like this and for me this has made it possible to actually use ssmtp with a custom configuration.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

Allows custom configuration for ssmtp

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested it by sending an e-mail to a smarthub in a fresh version of this docker image with this fix. Without the fix it would try to send e-mail through mail:25 which is in the default configuration.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
