### PR TITLE
Add an example Ipv6 Probe

### DIFF
--- a/root/defaults/smoke-conf/Probes
+++ b/root/defaults/smoke-conf/Probes
@@ -4,6 +4,11 @@
 
 binary = /usr/sbin/fping
 
++ FPing6
+
+binary = /usr/sbin/fping
+protocol = 6
+
 + DNS
 binary = /usr/bin/dig
 lookup = google.com

--- a/root/defaults/smoke-conf/Targets
+++ b/root/defaults/smoke-conf/Targets
@@ -32,6 +32,12 @@ menu = Google
 title = google.com
 host = google.com
 
+++ GoogleSearchIpv6
+menu = Google
+probe = FPing6
+title = ipv6.google.com
+host = ipv6.google.com
+
 ++ linuxserverio
 menu = linuxserver.io
 title = linuxserver.io


### PR DESCRIPTION
Fixes #93

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-smokeping/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

This adds an example Ipv6 probe

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested on a host with Ipv6 connectivity running the container with `--net=host`
