### PR TITLE
Update tcpping to allow the format of our tcptraceroute

### DIFF
--- a/tcpping
+++ b/tcpping
@@ -63,7 +63,7 @@ _testsite() {
 	[ "${d}" = "yes" ] && nowd=`date`
 	ttr=`tcptraceroute -f ${ttl} -m ${ttl} -q ${q} -w ${w} $* 2>/dev/null`
 	host=`echo "${ttr}" | awk '{print $2 " " $3}'`
-	rtt=`echo "${ttr}" | sed 's/.*] //' | awk '{print $1}'`
+        rtt=`echo "${ttr}" | sed 's/.*[])] //' | awk '{print $1}'`
 	not=`echo "${rtt}" | tr -d ".0123456789"`
 	[ "${d}" = "yes" ] && echo "$nowd"
 	if [ "${c}" = "yes" ]; then


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-smokeping/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

The format of the tcptraceroute command does not seem to match what is expected by the tcpping.

It appears that tcpping was expected tcptraceroute was outputting the IP address within brackets but tcptraceroute is actually outputting the IP in parens.

## Benefits of this PR and context:

It seems to make tcpping actually work.

## How Has This Been Tested?

I've built the docker container locally and ran it and it displayed real numbers instead of always 255ms.

