### PR TITLE
Smokeping version call depends on curl, install it first

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ COPY tcpping /defaults/
 
 RUN \
  echo "**** install packages ****" && \
+ apk add --no-cache \
+	curl && \
  if [ -z ${SMOKEPING_VERSION+x} ]; then \
 	SMOKEPING_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
 	&& awk '/^P:smokeping$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
@@ -23,7 +25,6 @@ RUN \
 	apache-mod-fcgid \
 	bc \
 	bind-tools \
-	curl \
 	font-noto-cjk \
 	openssh-client \
 	smokeping==${SMOKEPING_VERSION} \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -12,6 +12,8 @@ COPY tcpping /defaults/
 
 RUN \
  echo "**** install packages ****" && \
+ apk add --no-cache \
+	curl && \
  if [ -z ${SMOKEPING_VERSION+x} ]; then \
 	SMOKEPING_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
 	&& awk '/^P:smokeping$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
@@ -23,7 +25,6 @@ RUN \
 	apache-mod-fcgid \
 	bc \
 	bind-tools \
-	curl \
 	font-noto-cjk \
 	openssh-client \
 	smokeping==${SMOKEPING_VERSION} \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -12,6 +12,8 @@ COPY tcpping /defaults/
 
 RUN \
  echo "**** install packages ****" && \
+ apk add --no-cache \
+	curl && \
  if [ -z ${SMOKEPING_VERSION+x} ]; then \
 	SMOKEPING_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
 	&& awk '/^P:smokeping$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
@@ -23,7 +25,6 @@ RUN \
 	apache-mod-fcgid \
 	bc \
 	bind-tools \
-	curl \
 	font-noto-cjk \
 	openssh-client \
 	smokeping==${SMOKEPING_VERSION} \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -35,6 +35,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "29.03.21:", desc: "Dockerfile: Install curl before we call it" }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }


### PR DESCRIPTION
Dockerfile grabs the smokeping version in alpine's repo using curl but it isn't installed yet.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-smokeping/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Altered the Dockerfiles to install curl before it is called (to acquire smokeping version from alpine's repo)

## Benefits of this PR and context:
To allow a build to succeed

## How Has This Been Tested?
Built the image successfully
- On an x86 workstation running CentOS 7
- Inside the docker image (as part of a gitlab pipeline)

```
docker build \
  --no-cache \
  --pull \
  -t ghcr.io/linuxserver/smokeping:latest
```

Before the change:
```
Step 8/11 : RUN  echo "**** install packages ****" &&  if [ -z ${SMOKEPING_VERSION+x} ]; then 	SMOKEPING_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp 	&& awk '/^P:smokeping$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://');  fi &&  apk add --no-cache 	apache2 	apache2-ctl 	apache2-utils 	apache-mod-fcgid 	bc 	bind-tools 	curl 	font-noto-cjk 	openssh-client 	smokeping==${SMOKEPING_VERSION} 	ssmtp 	sudo 	tcptraceroute 	ttf-dejavu &&  echo "**** give setuid access to traceroute & tcptraceroute ****" &&  chmod a+s /usr/bin/traceroute &&  chmod a+s /usr/bin/tcptraceroute &&  echo "**** fix path to cropper.js ****" &&  sed -i 's#src="/cropper/#/src="cropper/#' /etc/smokeping/basepage.html &&  echo "**** install tcping script ****" &&  install -m755 -D /defaults/tcpping /usr/bin/ &&  echo "**** remove default apache conf ****" &&  rm -f /etc/apache2/httpd.conf
 ---> Running in 163da1268694
**** install packages ****
/bin/sh: curl: not found
tar: invalid magic
tar: short read
The command '/bin/sh -c echo "**** install packages ****" &&  if [ -z ${SMOKEPING_VERSION+x} ]; then 	SMOKEPING_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp 	&& awk '/^P:smokeping$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://');  fi &&  apk add --no-cache 	apache2 	apache2-ctl 	apache2-utils 	apache-mod-fcgid 	bc 	bind-tools 	curl 	font-noto-cjk 	openssh-client 	smokeping==${SMOKEPING_VERSION} 	ssmtp 	sudo 	tcptraceroute 	ttf-dejavu &&  echo "**** give setuid access to traceroute & tcptraceroute ****" &&  chmod a+s /usr/bin/traceroute &&  chmod a+s /usr/bin/tcptraceroute &&  echo "**** fix path to cropper.js ****" &&  sed -i 's#src="/cropper/#/src="cropper/#' /etc/smokeping/basepage.html &&  echo "**** install tcping script ****" &&  install -m755 -D /defaults/tcpping /usr/bin/ &&  echo "**** remove default apache conf ****" &&  rm -f /etc/apache2/httpd.conf' returned a non-zero code: 1
```

After:
```
Step 8/11 : RUN  echo "**** install packages ****" &&  apk add --no-cache 	curl &&  if [ -z ${SMOKEPING_VERSION+x} ]; then 	SMOKEPING_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp 	&& awk '/^P:smokeping$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://');  fi &&  apk add --no-cache 	apache2 	apache2-ctl 	apache2-utils 	apache-mod-fcgid 	bc 	bind-tools 	font-noto-cjk 	openssh-client 	smokeping==${SMOKEPING_VERSION} 	ssmtp 	sudo 	tcptraceroute 	ttf-dejavu &&  echo "**** give setuid access to traceroute & tcptraceroute ****" &&  chmod a+s /usr/bin/traceroute &&  chmod a+s /usr/bin/tcptraceroute &&  echo "**** fix path to cropper.js ****" &&  sed -i 's#src="/cropper/#/src="cropper/#' /etc/smokeping/basepage.html &&  echo "**** install tcping script ****" &&  install -m755 -D /defaults/tcpping /usr/bin/ &&  echo "**** remove default apache conf ****" &&  rm -f /etc/apache2/httpd.conf
 ---> Running in 507d35f32589
**** install packages ****
fetch http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
(1/4) Installing brotli-libs (1.0.9-r3)
(2/4) Installing nghttp2-libs (1.42.0-r1)
(3/4) Installing libcurl (7.74.0-r1)
(4/4) Installing curl (7.74.0-r1)
Executing busybox-1.32.1-r3.trigger
OK: 19 MiB in 37 packages
```