### PR TITLE
Make changes so Slave instances can be launched

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN \
 	curl \
 	font-noto-cjk \
 	openssh-client \
+	perl-lwp-protocol-https \
 	smokeping==${SMOKEPING_VERSION} \
 	ssmtp \
 	sudo \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -26,6 +26,7 @@ RUN \
 	curl \
 	font-noto-cjk \
 	openssh-client \
+	perl-lwp-protocol-https \
 	smokeping==${SMOKEPING_VERSION} \
 	ssmtp \
 	sudo \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -26,6 +26,7 @@ RUN \
 	curl \
 	font-noto-cjk \
 	openssh-client \
+	perl-lwp-protocol-https \
 	smokeping==${SMOKEPING_VERSION} \
 	ssmtp \
 	sudo \

--- a/root/etc/services.d/smokeping/run
+++ b/root/etc/services.d/smokeping/run
@@ -1,4 +1,10 @@
 #!/usr/bin/with-contenv bash
 
-exec s6-setuidgid abc  /usr/bin/smokeping --config="/etc/smokeping/config" --nodaemon
-
+if [ -a /config/MasterUrl ] && [ -a /config/SlaveSecret ]; then
+    chmod 600 /config/SlaveSecret
+    chmod 600 /config/MasterUrl
+    masterurl=$(cat /config/MasterUrl)
+    exec s6-setuidgid abc  /usr/bin/smokeping --master-url=$masterurl --cache-dir=/tmp --shared-secret=/config/SlaveSecret --nosleep --nodaemon
+else
+    exec s6-setuidgid abc  /usr/bin/smokeping --config="/etc/smokeping/config" --nodaemon
+fi

--- a/root/etc/services.d/smokeping/run
+++ b/root/etc/services.d/smokeping/run
@@ -4,7 +4,7 @@ if [ -a /config/MasterUrl ] && [ -a /config/SlaveSecret ]; then
     chmod 600 /config/SlaveSecret
     chmod 600 /config/MasterUrl
     masterurl=$(cat /config/MasterUrl)
-    exec s6-setuidgid abc  /usr/bin/smokeping --master-url=$masterurl --cache-dir=/tmp --shared-secret=/config/SlaveSecret --nosleep --nodaemon
+    exec s6-setuidgid abc  /usr/bin/smokeping --master-url=$masterurl --cache-dir=/tmp --shared-secret=/config/SlaveSecret --nodaemon
 else
     exec s6-setuidgid abc  /usr/bin/smokeping --config="/etc/smokeping/config" --nodaemon
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

### **This is a modified version of the following issue:** https://github.com/linuxserver/docker-smokeping/issues/115 **- credit should go to them for this pull.**

- /etc/services.d/smokeping/run

```
#!/usr/bin/with-contenv bash

if [ -a /config/MasterUrl ] && [ -a /config/SlaveSecret ]; then
    chmod 600 /config/SlaveSecret
    chmod 600 /config/MasterUrl
    masterurl=$(cat /config/MasterUrl)
    exec s6-setuidgid abc  /usr/bin/smokeping --master-url=$masterurl --cache-dir=/tmp --shared-secret=/config/SlaveSecret --nodaemon
else
    exec s6-setuidgid abc  /usr/bin/smokeping --config="/etc/smokeping/config" --nodaemon
fi
```

- perl-lwp-protocol-https was added to the installed packages to allow communication over https from master to slave.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

This adds master/slave configuration: https://oss.oetiker.ch/smokeping/doc/smokeping_master_slave.en.html

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Debian 11 build: `docker buildx build --platform linux/amd64,linux/arm64 -t registry.******.**/smokeping --push .`

- Tested on both amd64 and arm64: `docker run --hostname remote -d --name=smokeping_remote_1 -e PUID=1000 -e PGID=1000 -e TZ=Etc/UTC -v /opt/smokeping/config:/config -v /opt/smokeping/data:/data -p 127.0.0.1:1056:80 --restart unless-stopped registry.******.**/smokeping`

- I can confirm that the master/slave feature is working between a Raspberry Pi 4 (Debian 11) to remote VPS (Debian 11) over HTTPS through nginx reverse proxies: https://i.imgur.com/zHUciFJ.jpg

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

https://github.com/linuxserver/docker-smokeping/issues/115