### PR TITLE
Allowing the use of a port other than 80 for host=network use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,7 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-EXPOSE 80
+ARG PORT=80
+ENV PORT=${PORT}
+EXPOSE ${PORT}
 VOLUME /config /data

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -46,5 +46,7 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-EXPOSE 80
+ARG PORT=80
+ENV PORT=${PORT}
+EXPOSE ${PORT}
 VOLUME /config /data

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -46,5 +46,8 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-EXPOSE 80
+ARG PORT=80
+ENV PORT=${PORT}
+EXPOSE ${PORT}
+
 VOLUME /config /data

--- a/root/defaults/httpd.conf
+++ b/root/defaults/httpd.conf
@@ -59,7 +59,7 @@ ServerRoot /var/www
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 80
+Listen ${PORT}
 
 #
 # Dynamic Shared Object (DSO) Support


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-smokeping/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Use of the environment variable `PORT` in place of hard-coded `80`

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This addresses a difficulty in configuring docker to support IPv6 which is mitigated by allowing the container host network access. When doing this - there is no way to control which port the httpd server is listening on.
By adding a `PORT` environment variable, the container can be given `network_mode: host`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Configured httpd.conf to use environment variable, set environment variable

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
