### PR TITLE
Fix smokeping cgirul path

### DIFF
--- a/root/defaults/smoke-conf/General
+++ b/root/defaults/smoke-conf/General
@@ -6,7 +6,7 @@ mailhost = my.mail.host
 # NOTE: do not put the Image Cache below cgi-bin
 # since all files under cgi-bin will be executed ... this is not
 # good for images.
-cgiurl   = http://localhost/smokeping.cgi
+cgiurl   = http://localhost/smokeping/smokeping.cgi
 # specify this to get syslog logging
 syslogfacility = local0
 # each probe is now run in its own process


### PR DESCRIPTION
Using an unmodified default installation of this image the filter menu box on the main smokeping page does not function properly.  When entering text in this form field and pressing enter the result is a 404.  Updating the smokeping.cgi path to live under smokeping resolved the problem.