### PR TITLE
Add instructions to reload the configuration

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -28,9 +28,11 @@ param_env_vars:
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  * Once running the URL will be `http://<host-ip>/smokeping/smokeping.cgi`. For example a full URL might look like `https://smokeping.yourdomain.com/smokeping/smokeping.cgi`.
-  * Basics are, edit the `Targets` file to ping the hosts you're interested in to match the format found there.
+  * Once running, the URL will be `http://<host-ip>/smokeping/smokeping.cgi`. For example, a full URL might look like `https://smokeping.yourdomain.com/smokeping/smokeping.cgi`.
+  * Basic setup: edit the `Targets` file to ping the hosts you're interested in to match the format found there.
   * Wait 10 minutes.
+  * To reload the configuration without restarting the container, run `docker exec $CID s6-svc -h /run/service/svc-smokeping`, where `$CID` is the container ID (e.g., `smokeping`).
+  * To restart the container, run `docker restart $CID`.
 
 # changelog
 changelogs:

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -31,8 +31,8 @@ app_setup_block: |
   * Once running, the URL will be `http://<host-ip>/smokeping/smokeping.cgi`. For example, a full URL might look like `https://smokeping.yourdomain.com/smokeping/smokeping.cgi`.
   * Basic setup: edit the `Targets` file to ping the hosts you're interested in to match the format found there.
   * Wait 10 minutes.
-  * To reload the configuration without restarting the container, run `docker exec $CID pkill -f -HUP '/usr/bin/perl /usr/s?bin/smokeping(_cgi)?'`, where `$CID` is the container ID (e.g., `smokeping`).
-  * To restart the container, run `docker restart $CID`.
+  * To reload the configuration without restarting the container, run `docker exec smokeping pkill -f -HUP '/usr/bin/perl /usr/s?bin/smokeping(_cgi)?'`, where `smokeping` is the container ID.
+  * To restart the container, run `docker restart smokeping`, where `smokeping` is the container ID.
 
 # changelog
 changelogs:

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -31,7 +31,7 @@ app_setup_block: |
   * Once running, the URL will be `http://<host-ip>/smokeping/smokeping.cgi`. For example, a full URL might look like `https://smokeping.yourdomain.com/smokeping/smokeping.cgi`.
   * Basic setup: edit the `Targets` file to ping the hosts you're interested in to match the format found there.
   * Wait 10 minutes.
-  * To reload the configuration without restarting the container, run `docker exec $CID s6-svc -h /run/service/svc-smokeping`, where `$CID` is the container ID (e.g., `smokeping`).
+  * To reload the configuration without restarting the container, run `docker exec $CID pkill -f -HUP '/usr/bin/perl /usr/s?bin/smokeping(_cgi)?'`, where `$CID` is the container ID (e.g., `smokeping`).
   * To restart the container, run `docker restart $CID`.
 
 # changelog


### PR DESCRIPTION
Fixes #131. Instructions came from [this comment in #131](https://github.com/linuxserver/docker-smokeping/issues/131#issuecomment-1804065686).