### PR TITLE
add note about pre-existing config

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -33,6 +33,7 @@ app_setup_block: |
   * Wait 10 minutes.
   * To reload the configuration without restarting the container, run `docker exec smokeping pkill -f -HUP '/usr/bin/perl /usr/s?bin/smokeping(_cgi)?'`, where `smokeping` is the container ID.
   * To restart the container, run `docker restart smokeping`, where `smokeping` is the container ID.
+  * Note that the default `Targets` file includes items that may or may not work. These are simply to provide examples of configuration.
 
 # changelog
 changelogs:


### PR DESCRIPTION
Some of the stuff in the default Targets no longer work, comment in the readme that these are examples and may or may not be functional.
Resolves https://discourse.linuxserver.io/t/smokeping-100-paket-loss-with-sbb-ch-uea-ac-uk/7592/5