### PR TITLE
Add configuration for running smokeping in slave mode

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -24,6 +24,11 @@ param_ports:
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}
+opt_param_usage_include_env: true
+opt_param_env_vars:
+  - { env_var: "MASTER_URL", env_value: "http://{{master}}:8008/smokeping/", desc: "Specify the master url to connect to. Used when in slave mode."}
+  - { env_var: "SHARED_SECRET", env_value: "password", desc: "Specify the master shared secret for this host. Used when in slave mode."}
+  - { env_var: "CACHE_DIR", env_value: "/tmp", desc: "Specify the cache directory for this host. Used when in slave mode."}
 
 # application setup block
 app_setup_block_enabled: true

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -26,7 +26,7 @@ param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "MASTER_URL", env_value: "http://{{master}}:80/smokeping/", desc: "Specify the master url to connect to. Used when in slave mode."}
+  - { env_var: "MASTER_URL", env_value: "http://<master-host-ip>:80/smokeping/", desc: "Specify the master url to connect to. Used when in slave mode."}
   - { env_var: "SHARED_SECRET", env_value: "password", desc: "Specify the master shared secret for this host. Used when in slave mode."}
   - { env_var: "CACHE_DIR", env_value: "/tmp", desc: "Specify the cache directory for this host. Used when in slave mode."}
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,6 +39,7 @@ app_setup_block: |
   * To reload the configuration without restarting the container, run `docker exec smokeping pkill -f -HUP '/usr/bin/perl /usr/s?bin/smokeping(_cgi)?'`, where `smokeping` is the container ID.
   * To restart the container, run `docker restart smokeping`, where `smokeping` is the container ID.
   * Note that the default `Targets` file includes items that may or may not work. These are simply to provide examples of configuration.
+  * Slave setup: modify the `Targets`, `Slaves`, and `smokeping_secrets` files on the master host, per [the documentation](https://manpages.ubuntu.com/manpages/trusty/en/man7/smokeping_master_slave.7.html).
 
 # changelog
 changelogs:

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -43,6 +43,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "22.03.24:", desc: "Adding ability to run as a slave."}
   - { date: "23.12.23:", desc: "Rebase to Alpine 3.19."}
   - { date: "29.11.23:", desc: "Bump tcpping to 1.8." }
   - { date: "21.11.23:", desc: "Add support for IRTT Probes." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -26,7 +26,7 @@ param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "MASTER_URL", env_value: "http://{{master}}:8008/smokeping/", desc: "Specify the master url to connect to. Used when in slave mode."}
+  - { env_var: "MASTER_URL", env_value: "http://{{master}}:80/smokeping/", desc: "Specify the master url to connect to. Used when in slave mode."}
   - { env_var: "SHARED_SECRET", env_value: "password", desc: "Specify the master shared secret for this host. Used when in slave mode."}
   - { env_var: "CACHE_DIR", env_value: "/tmp", desc: "Specify the cache directory for this host. Used when in slave mode."}
 

--- a/root/defaults/smokeping_secrets
+++ b/root/defaults/smokeping_secrets
@@ -1,0 +1,3 @@
+host1:mysecret
+host2:yoursecret
+boomer:lkasdf93uhhfdfddf

--- a/root/etc/s6-overlay/s6-rc.d/init-smokeping-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-smokeping-config/run
@@ -43,6 +43,14 @@ if [[ ! -L /etc/apache2/httpd.conf ]]; then
     ln -sf /config/httpd.conf /etc/apache2/httpd.conf
 fi
 
+if [[ ! -e /config/smokeping_secrets ]]; then
+    cp /defaults/smokeping_secrets /config/smokeping_secrets
+fi
+
+if [[ ! -L /etc/smokeping/smokeping_secrets ]]; then
+    ln -sf /config/smokeping_secrets /etc/smokeping/smokeping_secrets
+fi
+
 if [[ -e /config/ssmtp.conf ]]; then
     cp /config/ssmtp.conf /etc/ssmtp/ssmtp.conf
 fi

--- a/root/etc/s6-overlay/s6-rc.d/svc-smokeping/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-smokeping/run
@@ -1,5 +1,11 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-exec \
-    s6-setuidgid abc /usr/sbin/smokeping --config="/etc/smokeping/config" --nodaemon
+if [ -n "${MASTER_URL}" ] && [ -n "${SHARED_SECRET}" ] && [ -n "${CACHE_DIR}" ]; then
+    install -g abc -o abc -m 400 -D <(echo $SHARED_SECRET) /var/smokeping/secret.txt
+    exec \
+        s6-setuidgid abc /usr/sbin/smokeping --master-url="${MASTER_URL}" --cache-dir="${CACHE_DIR}" --shared-secret="/var/smokeping/secret.txt" --nodaemon
+else
+    exec \
+        s6-setuidgid abc /usr/sbin/smokeping --config="/etc/smokeping/config" --nodaemon
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-smokeping/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
This change adds configuration (via environment variables) that allows for smokeping to be run in slave mode.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Running smokeping in slave mode has its advantages, as you can define configuration that is the source-of-truth on the master host, and replicate it across different machines throughout your network. This can help tease out latency issues that may be unique to certain segments of the network.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested locally on my network. I built and ran the docker image locally on my slave host (raspberry pi 4b running on ubuntu server 22.04). Everything works as expected.

You just need to modify the slaves, targets, and slavessecrets file on the master host, per [the documentation](https://manpages.ubuntu.com/manpages/trusty/en/man7/smokeping_master_slave.7.html).

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
