### PR TITLE
chore: fix targets: SBB and UEA

### DIFF
--- a/root/defaults/smoke-conf/Targets
+++ b/root/defaults/smoke-conf/Targets
@@ -74,7 +74,7 @@ host = cixp.web.cern.ch
 
 menu = SBB
 title = SBB
-host = www.sbb.ch/en
+host = www.sbb.ch
 
 ++ UK
 
@@ -91,7 +91,7 @@ host = cam.ac.uk
 
 menu = UEA
 title = UEA
-host = www.uea.ac.uk
+host = uea.ac.uk
 
 + USA
 


### PR DESCRIPTION
The SBB target was `www.sbb.ch/en` which doesn't work as a host. Change it to `www.sbb.ch`

The UEA target `www.uea.ac.uk` doesn't respond to pings. Maybe sometime between now and 2016 when the target was initially setup they started blocking pings. We can ping `uea.ac.uk` though, so change it to `uea.ac.uk`
