### PR TITLE
fix: Set max-age for image files to 300 seconds

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -85,6 +85,7 @@ init_diagram: |
   "smokeping:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "20.03.25:", desc: "Set max-age for image files to 300 seconds."}
   - {date: "27.07.24:", desc: "Add additional dependency packages for InfluxDB."}
   - {date: "25.06.24:", desc: "Rebase to Alpine 3.20."}
   - {date: "12.04.24:", desc: "Added perl InfluxDB HTTP module for InfluxDB HTTP support."}

--- a/root/defaults/httpd.conf
+++ b/root/defaults/httpd.conf
@@ -123,7 +123,7 @@ LoadModule log_config_module modules/mod_log_config.so
 #LoadModule logio_module modules/mod_logio.so
 LoadModule env_module modules/mod_env.so
 #LoadModule mime_magic_module modules/mod_mime_magic.so
-#LoadModule expires_module modules/mod_expires.so
+LoadModule expires_module modules/mod_expires.so
 LoadModule headers_module modules/mod_headers.so
 #LoadModule usertrack_module modules/mod_usertrack.so
 #LoadModule unique_id_module modules/mod_unique_id.so
@@ -278,6 +278,9 @@ DocumentRoot "/var/www/localhost/htdocs"
 RewriteEngine On
 RewriteRule ^/$ /smokeping/ [R]
 
+# Set max-age for image files to 300 seconds (5 minutes)
+ExpiresActive On
+ExpiresByType image/* A300
 
 #
 # The following lines prevent .htaccess and .htpasswd files from being


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-smokeping/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Enable the `mod_expires` Apache module, and configure it to request that image files are expired from the browser cache after 5 minutes (`max-age=300`).

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Currently, preview graphs are returned with `max-age=14400` in the `Cache-Control` HTTP response header. This means that preview graphs persist in the browser cache, and a forced reload is the only way to refresh them. This PR enables the `mod_expires` Apache module and configures it to request that image files are expired from the browser cache after 5 minutes (`max-age=300`).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Container builds and runs successfully. Images now have `max-age=300` set in the `Cache-Control` HTTP response header, according to the browser developer console.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
