### PR TITLE
Enable Curl as default probe type

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -85,6 +85,7 @@ init_diagram: |
   "smokeping:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "30.03.25:", desc: "Enable Curl as default probe type."}
   - {date: "27.07.24:", desc: "Add additional dependency packages for InfluxDB."}
   - {date: "25.06.24:", desc: "Rebase to Alpine 3.20."}
   - {date: "12.04.24:", desc: "Added perl InfluxDB HTTP module for InfluxDB HTTP support."}

--- a/root/defaults/smoke-conf/Probes
+++ b/root/defaults/smoke-conf/Probes
@@ -19,3 +19,11 @@ forks = 10
 offset = random
 pings = 5
 port = 80
+
++ Curl
+binary = /usr/bin/curl
+forks = 5
+offset = 50%
+step = 300
+pings = 5
+urlformat = http://%host%/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-smokeping/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Despite the `curl` binary is available, it's not possible to add target using `probe = Curl` in `Targets` because the probe is not declared in `Probes`. 

## Benefits of this PR and context:
This makes it easier to use probes of type `Curl`. In the readme there is no mention of the need to edit `Probes` file, only `Targets`.

## How Has This Been Tested?
This has been tested with a demo target. The minimal default values are taken from documentation.

## Discussion
* Shall there be a sample in the `Targets` file?
* Is the default config useful as is?
* Would it be better to use `AnotherCurl` instead of `Curl`?

## Source / References:
* [Documentation of the Curl Probe](https://oss.oetiker.ch/smokeping/probe/Curl.en.html)
* [Documentation of the AnotherCurl Probe](https://oss.oetiker.ch/smokeping/probe/AnotherCurl.en.html)
