### PR TITLE
Allow manual setting of slave name

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-smokeping/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-smokeping/run
@@ -3,8 +3,13 @@
 
 if [ -n "${MASTER_URL}" ] && [ -n "${SHARED_SECRET}" ] && [ -n "${CACHE_DIR}" ]; then
     install -g abc -o abc -m 400 -D <(echo $SHARED_SECRET) /var/smokeping/secret.txt
+    if [ -n "${SLAVE_NAME}" ]; then
+        SLAVE_NAME_OPTION="--slave-name=\"${SLAVE_NAME}\""
+    else
+        SLAVE_NAME_OPTION=""
+    fi
     exec \
-        s6-setuidgid abc /usr/sbin/smokeping --master-url="${MASTER_URL}" --cache-dir="${CACHE_DIR}" --shared-secret="/var/smokeping/secret.txt" --nodaemon
+        s6-setuidgid abc /usr/sbin/smokeping --master-url="${MASTER_URL}" --cache-dir="${CACHE_DIR}" --shared-secret="/var/smokeping/secret.txt" ${SLAVE_NAME_OPTION} --nodaemon
 else
     exec \
         s6-setuidgid abc /usr/sbin/smokeping --config="/etc/smokeping/config" --nodaemon

--- a/root/etc/s6-overlay/s6-rc.d/svc-smokeping/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-smokeping/run
@@ -4,7 +4,7 @@
 if [ -n "${MASTER_URL}" ] && [ -n "${SHARED_SECRET}" ] && [ -n "${CACHE_DIR}" ]; then
     install -g abc -o abc -m 400 -D <(echo $SHARED_SECRET) /var/smokeping/secret.txt
     if [ -n "${SLAVE_NAME}" ]; then
-        SLAVE_NAME_OPTION="--slave-name=\"${SLAVE_NAME}\""
+        SLAVE_NAME_OPTION="--slave-name=${SLAVE_NAME}"
     else
         SLAVE_NAME_OPTION=""
     fi


### PR DESCRIPTION
Allow manual setting of slave name via "SLAVE_NAME" env variable, as e.g. [ECS with Fargate does not support setting the hostname of a container (task)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#ContainerDefinition-hostname).

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-smokeping/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Allow manual setting of slave name via "SLAVE_NAME" env variable, as e.g. ECS with Fargate does not support setting the hostname of a container (task).

## Benefits of this PR and context:
Allow manual setting of slave name via "SLAVE_NAME" env variable, as e.g. ECS with Fargate does not support setting the hostname of a container (task).

## How Has This Been Tested?
Tested in custom container image with implemented change on ECS with Fargate.

## Source / References:
N/A
