### PR TITLE
fix: Remove Indiana University as a default

### DIFF
--- a/root/defaults/smoke-conf/Targets
+++ b/root/defaults/smoke-conf/Targets
@@ -104,12 +104,6 @@ menu = MIT
 title = Massachusetts Institute of Technology Webserver
 host = web.mit.edu
 
-++ IU
-
-menu = IU
-title = Indiana University
-host = www.indiana.edu
-
 ++ UCB
 
 menu = U. C. Berkeley


### PR DESCRIPTION
Indiana University's old website now redirects. Neither the new nor the old site respond to pings. Thus, there is no point in having them listed as defaults.