### PR TITLE
fix: replace busybox traceroute with APK version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN \
     smokeping==${SMOKEPING_VERSION} \
     ssmtp \
     sudo \
+    traceroute \
     tcptraceroute && \
   echo "**** Build perl TacacsPlus module ****" && \
   cpanm Authen::TacacsPlus && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -37,6 +37,7 @@ RUN \
     smokeping==${SMOKEPING_VERSION} \
     ssmtp \
     sudo \
+    traceroute \
     tcptraceroute && \
   echo "**** Build perl TacacsPlus module ****" && \
   cpanm Authen::TacacsPlus && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -83,6 +83,7 @@ init_diagram: |
   "smokeping:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "17.12.25:", desc: "Replace busybox traceroute with APK version."}
   - {date: "26.09.25:", desc: "Add IO::Socket::INET6 perl module to improve IPv6 abilities."}
   - {date: "05.06.25:", desc: "Update TCPPing to 2.7 to fix traceroute incompatibility."}
   - {date: "03.06.25:", desc: "Rebase to Alpine 3.22. Update TCPPing. Add curl probe."}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-smokeping/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Replace the busybox `traceroute` binary with the more fully-featured one available in the `community` APK repository.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This allows the `tcpping` script to leverage `traceroute` instead of falling back to `tcptraceroute`. `tcptraceroute` has some strange issues with certain types of responses, notably an unexplained delay in processing responses from specific targets:

```
$ docker compose exec --user abc smokeping time /usr/bin/tcpping -Czx 25 speedtest.qld.edgeix.net.au 8080
traceroute does not support -M parameter, switching to tcptraceroute
/usr/bin/tcptraceroute -f 255 -m 255 -q 1 -w 1  speedtest.qld.edgeix.net.au 8080
speedtest.qld.edgeix.net.au : 4.045 7.251 13.231 9.323 11.507 10.339 8.279 8.171 4.429 5.751 5.520 8.590 4.451 11.315 11.588 5.221 5.022 4.892 6.489 4.892 4.753 4.527 10.546 5.053 10.615

real	4m 29.37s
user	0m 0.16s
sys	0m 0.11s
```

Running `tcptraceroute` directly with the `-d` flag reveals that each execution of `tcptraceroute` against this target takes 10 seconds, although the response is received much faster than that:

```
$ docker compose exec --user abc smokeping time /usr/bin/tcptraceroute -f 255 -m 255 -q 1 -w 1 -d -A speedtest.qld.edgeix.net.au 8080
debug: tcptraceroute 1.5beta7, x86_64-alpine-linux-musl
debug: Compiled with libpcap 1.10.5, libnet 1.3 (API 110)
debug: o_ack set
debug: entering getinterfaces()
debug: ifreq buffer set to 32
debug: Successfully retrieved interface list
debug: Discovered interface lo with address 127.0.0.1
debug: Discovered interface eth0 with address 10.5.1.25
debug: Discovered interface eth1 with address 192.168.0.25
debug: leaving getinterfaces()
debug: Determined source address of 192.168.0.25 to reach 103.215.15.11
debug: entering finddev()
debug: finddev() returning eth1
debug: debugoptions():
debug:         TEXTSIZE: 1024        SNAPLEN: 92     IPTOSBUFFERS: 12
debug: ALLOCATEID_CACHE: 512        datalink: 1    datalinkoffset: 14
debug:         o_minttl: 255         o_maxttl: 255        o_timeout: 1
debug:          o_debug: 1         o_numeric: 0          o_pktlen: 0
debug:       o_nqueries: 1        o_dontfrag: 0             o_tos: 0
debug:      o_forceport: 0             o_syn: 0             o_ack: 1
debug:            o_ecn: 0        o_nofilter: 0 o_nogetinterfaces: 0
debug:      o_trackport: 0      datalinkname: ETHERNET     device: eth1
debug:       o_noselect: 0            o_dnat: 0               isn: 1019473394
Selected device eth1, address 192.168.0.25, port 42173 for outgoing packets
debug: pcap filter is:
		(tcp and src host 103.215.15.11 and src port 8080 and dst host 192.168.0.25)
		or ((icmp[0] == 11 or icmp[0] == 3) and dst host 192.168.0.25)
Tracing the path to speedtest.qld.edgeix.net.au (103.215.15.11) on TCP port 8080 (http-alt), 255 hops max
debug: Generating a new batch of 512 IP ID's
debug: Sent probe 1 of 1 for hop 255, IP ID 39778, source port 42173, ACK
debug: received 46 byte IP packet from pcap_next()
debug: Received TCP packet
debug: Received TCP packet 103.215.15.11:8080 -> 192.168.0.25:42173, flags RST
debug: displayed hop
255  103.215.15.11 [closed]  5.529 ms

real	0m 10.10s
user	0m 0.00s
sys	0m 0.00s
```

`tcptraceroute` is also [effectively unmaintained](https://github.com/mct/tcptraceroute). The latest release (and the one available in the image) is v1.5beta7, released in 2006, and there have been no commits to the repository since 2017, so I'm not expecting any bugs to be fixed any time soon. I've elected to keep the installation of `tcptraceroute` in the Dockerfile despite this, to avoid breaking any configurations in the wild that explicitly rely on its presence.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I installed the updated `traceroute` binary in an existing `docker-smokeping` container using `apk -U add traceroute` and gave the binary setuid access with `chmod a+s /usr/bin/traceroute`. A test of `tcpping` using the `-z` flag shows the correct binary and flags being used:

```
$ docker compose exec --user abc smokeping time /usr/bin/tcpping -Czx 25 speedtest.qld.edgeix.net.au 8080
/usr/bin/traceroute -M tcp -f 255 -m 255 -q 1 -w 1  -p 8080 speedtest.qld.edgeix.net.au
speedtest.qld.edgeix.net.au : 10.830 6.358 9.224 6.599 5.644 12.996 9.713 4.803 4.589 4.373 4.332 6.743 5.734 6.043 10.443 5.303 13.648 14.440 4.685 4.452 4.590 5.220 9.463 9.294 5.290

real	0m 17.85s
user	0m 0.14s
sys	0m 0.10s
```

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
