### PR TITLE
Fix: support Apache Listen ip:port format in healthcheck

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-apache/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-apache/run
@@ -2,7 +2,10 @@
 # shellcheck shell=bash
 
 if [[ -f "/config/httpd.conf" ]]; then
-    PORT=$(grep -e "^Listen" /config/httpd.conf | awk -F ' ' '{print $2}')
+    PORT=$(grep -e "^Listen" /config/httpd.conf \
+        | awk '{print $2}' \
+        | awk -F: '{print $NF}' \
+        | head -n1)
 fi
 
 exec \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-smokeping/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

The current implementation assumes that the Apache Listen directive
contains only a port number (e.g. "Listen 80").

However, Apache also supports the "ip:port" format, such as:
    Listen 127.0.0.1:3000

In this case, the existing parsing logic extracts "127.0.0.1:3000"
and passes it directly to netcat as the port argument, which results in:

    nc: port number invalid

This PR updates the parsing logic to extract only the port portion
from the Listen directive, ensuring compatibility with both formats.

It also ensures only the first Listen directive is used to avoid
passing multiple ports to netcat.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

- Fixes incorrect healthcheck behavior when using "Listen ip:port"
- Maintains full backward compatibility with existing configurations
- Prevents netcat invocation errors due to invalid port format
- Adds basic safety by selecting only the first Listen directive

This change improves robustness without altering existing behavior
for standard configurations.

This issue may occur when users run the container with host networking
and bind Apache explicitly to localhost (127.0.0.1).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in a Docker environment using linuxserver/smokeping:2.9.0.

Test cases:

1. Default configuration:
   Listen 80
   → Healthcheck works as expected

2. Custom port:
   Listen 3000
   → Healthcheck works as expected

3. IP + port configuration:
   Listen 127.0.0.1:3000
   → Previously failed with:
       nc: port number invalid
   → After patch:
       Healthcheck succeeds correctly

4. Multiple Listen directives:
   Listen 127.0.0.1:3000
   Listen 0.0.0.0:8080
   → Healthcheck uses the first Listen directive (3000)
   → Container starts and healthcheck succeeds

Also verified that the container starts normally and Apache becomes available
without impacting other functionality.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

Apache Listen directive documentation:
https://httpd.apache.org/docs/current/mod/mpm_common.html#listen

Netcat usage reference:
nc -z <host> <port>

This issue was identified by inspecting the generated s6 service run script:
    /var/run/s6/db/servicedirs/svc-apache/run